### PR TITLE
Add Helm Chart

### DIFF
--- a/charts/verizon-router-operator/.helmignore
+++ b/charts/verizon-router-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/verizon-router-operator/Chart.yaml
+++ b/charts/verizon-router-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: verizon-router-operator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"

--- a/charts/verizon-router-operator/crds/crd-fiosdnsrecord.yaml
+++ b/charts/verizon-router-operator/crds/crd-fiosdnsrecord.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fiosdnsrecords.network.verizon.com
+spec:
+  group: network.verizon.com
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - hostname
+                - ip
+              properties:
+                hostname:
+                  type: string
+                  description: The hostname for the DNS record
+                ip:
+                  type: string
+                  description: The IPv4 address for the DNS record
+      additionalPrinterColumns:
+      - name: Hostname
+        type: string
+        description: The hostname
+        jsonPath: .spec.hostname
+      - name: IP
+        type: string
+        description: The IP Address
+        jsonPath: .spec.ip
+  scope: Namespaced
+  names:
+    plural: fiosdnsrecords
+    singular: fiosdnsrecord
+    kind: FiosDnsRecord
+    shortNames:
+      - fdr

--- a/charts/verizon-router-operator/crds/crd-fiosportforward.yaml
+++ b/charts/verizon-router-operator/crds/crd-fiosportforward.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fiosportforwards.network.verizon.com
+spec:
+  group: network.verizon.com
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - name
+                - private_ip
+                - forward_port
+                - dest_port
+              properties:
+                name:
+                  type: string
+                  description: The name of the Port Forwarding rule
+                private_ip:
+                  type: string
+                  description: The private IPv4 address to forward to
+                forward_port:
+                  type: integer
+                  description: The port to forward from (external port)
+                dest_port:
+                  type: integer
+                  description: The destination port to forward to (internal port)
+      additionalPrinterColumns:
+      - name: Rule Name
+        type: string
+        description: The rule name
+        jsonPath: .spec.name
+      - name: Private IP
+        type: string
+        description: The private IP
+        jsonPath: .spec.private_ip
+      - name: Forward Port
+        type: integer
+        description: The external forward port
+        jsonPath: .spec.forward_port
+      - name: Dest Port
+        type: integer
+        description: The internal destination port
+        jsonPath: .spec.dest_port
+  scope: Namespaced
+  names:
+    plural: fiosportforwards
+    singular: fiosportforward
+    kind: FiosPortForward
+    shortNames:
+      - fpf

--- a/charts/verizon-router-operator/templates/_helpers.tpl
+++ b/charts/verizon-router-operator/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "verizon-router-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "verizon-router-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "verizon-router-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "verizon-router-operator.labels" -}}
+helm.sh/chart: {{ include "verizon-router-operator.chart" . }}
+{{ include "verizon-router-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "verizon-router-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "verizon-router-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ include "verizon-router-operator.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "verizon-router-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "verizon-router-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/verizon-router-operator/templates/deployment.yaml
+++ b/charts/verizon-router-operator/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "verizon-router-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "verizon-router-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "verizon-router-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "verizon-router-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "verizon-router-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ROUTER_BASE_URL
+              value: {{ .Values.router.baseUrl | quote }}
+            - name: ROUTER_USERNAME
+              value: {{ .Values.router.username | quote }}
+            {{- if .Values.router.existingSecret }}
+            - name: ROUTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.router.existingSecret }}
+                  key: {{ .Values.router.existingSecretPasswordKey | default "password" }}
+            {{- else if .Values.router.password }}
+            - name: ROUTER_PASSWORD
+              value: {{ .Values.router.password | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/verizon-router-operator/templates/rbac.yaml
+++ b/charts/verizon-router-operator/templates/rbac.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "verizon-router-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "verizon-router-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "verizon-router-operator.fullname" . }}
+  labels:
+    {{- include "verizon-router-operator.labels" . | nindent 4 }}
+rules:
+  # Framework: knowing which other operators are running (i.e. peering).
+  - apiGroups: [kopf.dev]
+    resources: [clusterkopfpeerings]
+    verbs: [list, watch, patch, get]
+
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+
+  # Framework: admission webhook configuration management.
+  - apiGroups: [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+
+  # Application: read-only access for watching & handling events.
+  - apiGroups: [network.verizon.com]
+    resources: [fiosdnsrecords, fiosportforwards]
+    verbs: [list, watch, patch, get]
+
+  # Application: events
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "verizon-router-operator.fullname" . }}
+  labels:
+    {{- include "verizon-router-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "verizon-router-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "verizon-router-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/verizon-router-operator/values.yaml
+++ b/charts/verizon-router-operator/values.yaml
@@ -1,0 +1,70 @@
+# Default values for verizon-router-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: verizon-router-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  # Specifies whether RBAC rules should be created
+  create: true
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+router:
+  # URL of the Verizon Fios Router
+  baseUrl: "https://192.168.1.1"
+  # Username to login to the router
+  username: "admin"
+  # Password to login to the router
+  # password: ""
+  # Or use an existing secret that holds the password
+  existingSecret: "verizon-router-secret"
+  existingSecretPasswordKey: "password"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Adds a new Helm chart to the repository under `charts/verizon-router-operator/` to allow deploying the operator more easily and uniformly.
- Moves `crd-*` files into `crds/` folder.
- Converts `rbac.yaml` and `deployment.yaml` into customizable Helm templates.
- Configures default `values.yaml` with safe secret defaults.

---
*PR created automatically by Jules for task [16795806888268925484](https://jules.google.com/task/16795806888268925484) started by @Brishen*