### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/charts/verizon-router-operator/Chart.yaml
+++ b/charts/verizon-router-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "verizon-router-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python client for Verizon Fios router APIs (CR1000A web UI endpoints)."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "verizon-router-client"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Updates version from 0.1.0 to 0.2.0 in `pyproject.toml` and `charts/verizon-router-operator/Chart.yaml`, updates `uv.lock`, and tags the commit with `v0.2.0`.

---
*PR created automatically by Jules for task [15026316103570679903](https://jules.google.com/task/15026316103570679903) started by @Brishen*